### PR TITLE
Support Sqlite database dbup in MAUI Android OS

### DIFF
--- a/src/dbup-sqlite/dbup-sqlite.csproj
+++ b/src/dbup-sqlite/dbup-sqlite.csproj
@@ -6,7 +6,7 @@
     <Company>DbUp Contributors</Company>
     <Product>DbUp</Product>
     <Copyright>Copyright © DbUp Contributors 2015</Copyright>
-    <TargetFrameworks>netstandard1.3;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net462;netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>dbup-sqlite</AssemblyName>
     <RootNamespace>DbUp.SQLite</RootNamespace>
     <PackageId>dbup-sqlite</PackageId>
@@ -20,13 +20,21 @@
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0'">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="dbup-core" Version="5.0.37"/>
+    <PackageReference Include="dbup-core" Version="5.0.87" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.0.1" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
+  </ItemGroup>  
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
@@ -35,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Visible="false" Include="../dbup-icon.png" Pack="True" PackagePath=""/>
+    <None Visible="false" Include="../dbup-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- add netstandard2.0 and net6.0 target framework (align with dbup-core)
- add package Microsost.Data.Sqlite for netstandard2.0 and net6.0 target framework
- update dbup-core package to version 5.0.87

# Checklist
- [ ] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [ ] I have checked to ensure this does not introduce an unintended breaking changes
- [ ] I have considered appropriate testing for my change

# Description
